### PR TITLE
Replace a placeholder in the path to the plugins folder.

### DIFF
--- a/wiki/CreatingPlugins.md
+++ b/wiki/CreatingPlugins.md
@@ -6,7 +6,7 @@ The easiest way to test out new content for Endless Sky is to create a plugin. A
 
 #### Windows
 * plugins\ (in the same folder as the Endless Sky executable)
-* C:\Users\yourusername\AppData\Roaming\endless-sky\plugins\
+* %APPDATA%\endless-sky\plugins\
 
 #### macOS
 * Contents/Resources/plugins/ (within the application bundle)


### PR DESCRIPTION
**Correction/Clarification** probably

## Summary
On the CreatingPlugins page, replaced a fragment of the path to the `plugins\` directory on Windows with the `%APPDATA%` environment variable, similarly to how other systems use the `~/` directory.