### PR TITLE
Fix Footer

### DIFF
--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,2 +1,2 @@
-This wiki is based on files at https://github.com/endless-sky/endless-sky-wiki
+This wiki is based on files at https://github.com/endless-sky/endless-sky-wiki.
 If you find any errors or omissions, or would like to suggest a change, please do so there.


### PR DESCRIPTION
**Typo fix**


## Summary

In the footer I added a period so that there wouldn’t be an enter with nothing before it (see the diff, because this is probably unclear)