### PR TITLE
Clarification: Add default values to MapData

### DIFF
--- a/wiki/MapData.md
+++ b/wiki/MapData.md
@@ -537,7 +537,7 @@ security <security#>
 
 The behavior that this planet has when the player has illegal goods or outfits. The bribe number is a multiplier that modifies the severity of any fines, while the security number is a value between 0 and 1 that dictates the chance of a player's ship being scanned.
 
-If no security is specified, then a default security of 0.25 is used. 
+If no bribe is specified, then a default bribe of 0.01 is used. If no security is specified, then it defaults to 0.25. 
 
 ```html
 wormhole <name>
@@ -565,7 +565,7 @@ The number of credits that will be paid to the player per day if this planet has
 threshold <rating#>
 ```
 
-The combat rating that the player must have before being capable of demanding tribute from this planet.
+The combat rating that the player must have before being capable of demanding tribute from this planet. If no threshold is specified, then a default threshold of 4000 will be used.
 
 ```html
 fleet <name> <count#>

--- a/wiki/MapData.md
+++ b/wiki/MapData.md
@@ -537,7 +537,8 @@ security <security#>
 
 The behavior that this planet has when the player has illegal goods or outfits. The bribe number is a multiplier that modifies the severity of any fines, while the security number is a value between 0 and 1 that dictates the chance of a player's ship being scanned.
 
-If no bribe is specified, then a default bribe of 0.01 is used. If no security is specified, then it defaults to 0.25. 
+If no bribe is specified, then a default bribe of 0.01 is used.
+If no security is specified, then a default security of 0.25 is used. 
 
 ```html
 wormhole <name>
@@ -565,7 +566,7 @@ The number of credits that will be paid to the player per day if this planet has
 threshold <rating#>
 ```
 
-The combat rating that the player must have before being capable of demanding tribute from this planet. If no threshold is specified, then a default threshold of 4000 will be used.
+The combat rating that the player must have before being capable of demanding tribute from this planet. If no threshold is specified, then a default threshold of 4000 is used.
 
 ```html
 fleet <name> <count#>


### PR DESCRIPTION
**Clarification**

## Summary

I was looking through MapData trying to remember how to set up planet definitions, when I realized that the default bribe wasn't listed, nor was the default required CR for demanding tribute. This PR adds both based on what's in `Planet.h`.