### PR TITLE
Outfit jump range overridden by system jump range

### DIFF
--- a/wiki/CreatingOutfits.md
+++ b/wiki/CreatingOutfits.md
@@ -441,7 +441,7 @@ Unless otherwise stated, other outfit attributes will stack additively between m
 
   * `"jump base mass"`: a value that subtracts from a ship's mass during the jump mass cost calculation. If a drive's jump base mass is high enough and the ship's mass is low enough, the impact of the jump mass cost is allowed to go negative and begin subtracting from the normal jump fuel cost. Reducing your jump cost in this manner is only allowed to go as low as a cost of 1 fuel per jump. **(v. 0.10.0)**
 
-  * `"jump range"`: how far a ship can jump when using this outfit. The default jump range is 100. As with jump fuel, jump range does not stack between outfits. The outfit with the highest jump range will dictate the farthest a ship can jump. If a ship has multiple outfits with varying jump ranges, the one with the lowest jump fuel that is capable of making the given jump will be used. **(v. 0.9.13)**
+  * `"jump range"`: how far a ship can jump when using this outfit. The default jump range is 100. As with jump fuel, jump range does not stack between outfits. The outfit with the highest jump range will dictate the farthest a ship can jump. If a ship has multiple outfits with varying jump ranges, the one with the lowest jump fuel that is capable of making the given jump will be used. System-defined jump ranges override outfit-defined ones. **(v. 0.9.13)**
 
 * These attributes can be used to alter the crew stats of a ship.
 


### PR DESCRIPTION
**Correction/Clarification**

## Summary

The MapData page tells you that system-defined jump ranges override outfit-defined jump ranges, but CreatingOutfits does not. This fixes that.

Thanks to @SomeTroglodyte, who points problems out but doesn't make PRs for them. https://github.com/endless-sky/endless-sky/issues/10462#issuecomment-2353444905