### PR TITLE
fix: Add missing ring/bar interface properties

### DIFF
--- a/wiki/CreatingInterfaces.md
+++ b/wiki/CreatingInterfaces.md
@@ -252,7 +252,8 @@ If `color` is defined but either the inactive or hover color is not, the undefin
 Defines a straight line (bar) or circular outline (ring) to be drawn with this interface.
 In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box. The start and span angle specifies the portion of the ring that is drawn **(v. 0.10.2)**.
 A bar will be drawn from the bottom right corner of its bounding box.
-At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar. If only a part is drawn, the reversed attribute can toggle which end it is filled from **(v. 0.10.3)**.
+At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar.
+Beginning in **v0.10.3**, "reversed" can be used to invert the fill direction. A reversed ring will be filled in the clockwise direction, and a reversed bar will be filled from the top left corner.
 The size determines the thickness of the bar or ring, the default value is 2.
 If no color is given, "active" will be used.
 

--- a/wiki/CreatingInterfaces.md
+++ b/wiki/CreatingInterfaces.md
@@ -250,9 +250,9 @@ If `color` is defined but either the inactive or hover color is not, the undefin
 		[span angle <angle#>>]
 ```
 Defines a straight line (bar) or circular outline (ring) to be drawn with this interface.
-In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box. The start and span angle specifies the portion of the ring that is drawn.
+In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box. The start and span angle specifies the portion of the ring that is drawn **(v. 0.10.2)**.
 A bar will be drawn from the bottom right corner of its bounding box.
-At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar. If only a part is drawn, the reversed attribute can toggle which end it is filled from.
+At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar. If only a part is drawn, the reversed attribute can toggle which end it is filled from **(v. 0.10.3)**.
 The size determines the thickness of the bar or ring, the default value is 2.
 If no color is given, "active" will be used.
 

--- a/wiki/CreatingInterfaces.md
+++ b/wiki/CreatingInterfaces.md
@@ -45,6 +45,9 @@ interface <name> [<anchor>]
 		dimensions <x#> <y#>
 		[color <color>]
 		[size <size#>]
+		[reversed]
+		[start angle <angle#>]
+		[span angle <angle#>>]
 	pointer
 		from <x#> <y#>
 		to <x#> <y#>
@@ -242,11 +245,14 @@ If `color` is defined but either the inactive or hover color is not, the undefin
 		from <x#> <y#> to <x#> <y#> [<anchor>]
 		color <color>
 		size <size#>
+		[reversed]
+		[start angle <angle#>]
+		[span angle <angle#>>]
 ```
 Defines a straight line (bar) or circular outline (ring) to be drawn with this interface.
-In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box.
+In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box. The start and span angle specifies the portion of the ring that is drawn.
 A bar will be drawn from the bottom right corner of its bounding box.
-At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar.
+At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar. If only a part is drawn, the reverse attribute can toggle which end it is filled from.
 The size determines the thickness of the bar or ring, the default value is 2.
 If no color is given, "active" will be used.
 

--- a/wiki/CreatingInterfaces.md
+++ b/wiki/CreatingInterfaces.md
@@ -252,7 +252,7 @@ If `color` is defined but either the inactive or hover color is not, the undefin
 Defines a straight line (bar) or circular outline (ring) to be drawn with this interface.
 In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box.
 Beginning in **v. 0.10.2**, it is also possible to define the "start angle" and "span angle" for a ring.
-The "start angle" defines from how many degrees clockwise from a line straight up from the centre the ring should start filling. The default value is 0, which corresponds to straight up. Values of greater than or equal to zero and less than 360 are allowed.
+The "start angle" defines from how many degrees clockwise from a line straight up from the center the ring should start filling. The default value is 0, which corresponds to straight up. Values of greater than or equal to zero and less than 360 are allowed.
 The "span angle" defines how many degrees the ring should be drawn through when fully filled. The default, and maximum, value is 360, where the full ring will correspond to a full circle. The minimum value is 0, in which case, nothing is drawn.
 A bar will be drawn from the bottom right corner of its bounding box.
 At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar.

--- a/wiki/CreatingInterfaces.md
+++ b/wiki/CreatingInterfaces.md
@@ -252,7 +252,7 @@ If `color` is defined but either the inactive or hover color is not, the undefin
 Defines a straight line (bar) or circular outline (ring) to be drawn with this interface.
 In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box. The start and span angle specifies the portion of the ring that is drawn.
 A bar will be drawn from the bottom right corner of its bounding box.
-At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar. If only a part is drawn, the reverse attribute can toggle which end it is filled from.
+At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar. If only a part is drawn, the reversed attribute can toggle which end it is filled from.
 The size determines the thickness of the bar or ring, the default value is 2.
 If no color is given, "active" will be used.
 

--- a/wiki/CreatingInterfaces.md
+++ b/wiki/CreatingInterfaces.md
@@ -250,7 +250,10 @@ If `color` is defined but either the inactive or hover color is not, the undefin
 		[span angle <angle#>>]
 ```
 Defines a straight line (bar) or circular outline (ring) to be drawn with this interface.
-In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box. The start and span angle specifies the portion of the ring that is drawn **(v. 0.10.2)**.
+In the case of a ring, it will be drawn anti-clockwise around the center of its bounding box, with a radius equal to half the width of the bounding box.
+Beginning in **v. 0.10.2**, it is also possible to define the "start angle" and "span angle" for a ring.
+The "start angle" defines from how many degrees clockwise from a line straight up from the centre the ring should start filling. The default value is 0, which corresponds to straight up. Values of greater than or equal to zero and less than 360 are allowed.
+The "span angle" defines how many degrees the ring should be drawn through when fully filled. The default, and maximum, value is 360, where the full ring will correspond to a full circle. The minimum value is 0, in which case, nothing is drawn.
 A bar will be drawn from the bottom right corner of its bounding box.
 At runtime, the game may only partially complete the bar or ring, or segment it, for example, the ship hull status ring, or the fuel bar.
 Beginning in **v0.10.3**, "reversed" can be used to invert the fill direction. A reversed ring will be filled in the clockwise direction, and a reversed bar will be filled from the top left corner.


### PR DESCRIPTION
**Correction/Clarification**

Adds three missing interface properties to bars/rings.

## Summary
The documentation didn't have `reversed`, `start angle` and `span angle`.