### PR TITLE
Feature: Formatting in `on display/reveal`

### DIFF
--- a/wiki/Creating-Starts.md
+++ b/wiki/Creating-Starts.md
@@ -224,7 +224,7 @@ on (display | reveal)
 
 The `on display` and `on reveal` nodes specify display information that is displayed in lieu of the true information if the start is not fully unlocked, as described above.
 
-Note that unlike the true start information, the `on (display | reveal)` information does not need to display information that actually exists or is properly formatted. That is to say, the planet and system provided do not need to be real, and the date, credits, and debt do not need to be formatted as a date or as credit amounts and can simply be descriptors if you so desire.
+Note that unlike the true start information, the `on (display | reveal)` information does not need to display information that actually exists or is properly formatted. That is to say, the planet and system provided do not need to be real, and the date, credits, and debt do not need to be formatted as a date or as credit amounts and can simply be descriptors if you so desire. If they are formatted as date or credit amounts, they will be displayed accordingly.
 
 If a start has a `to reveal` or `to unlock` node, but does not have an `on display` or `on reveal` node, then the displayed information defaults to "???".
 


### PR DESCRIPTION
## Summary
`Creating-Starts.md` now references the ability for `on display` and `on reveal` to have formatted dates and credits, as added by https://github.com/endless-sky/endless-sky/pull/10754.