### PR TITLE
Mission offer precedence documentation

### DIFF
--- a/wiki/CreatingMissions.md
+++ b/wiki/CreatingMissions.md
@@ -98,6 +98,7 @@ mission <name>
 		<text> <replacement>
 			[<condition set>]
 		...
+	"offer precedence" <value>
 	to (offer | complete | fail | accept)
 		<condition> <comp> <value>
 		(has | not) <condition>
@@ -446,7 +447,15 @@ substitutions
 	...
 ```
 
-Beginning with **v.0.9.15**, this specifies custom text replacements that apply only to the text of the mission they're defined within. Substitutions defined within a mission take precedence over global substitutions and are overtaken in precedence by [hardcoded text replacements](#text-replacements). For more information on custom text replacements, see the [creating substitutions](CreatingSubstitutions) page.
+Beginning with **v. 0.9.15**, this specifies custom text replacements that apply only to the text of the mission they're defined within. Substitutions defined within a mission take precedence over global substitutions and are overtaken in precedence by [hardcoded text replacements](#text-replacements). For more information on custom text replacements, see the [creating substitutions](CreatingSubstitutions) page.
+
+```html
+"offer precedence" <value>
+```
+
+Beginning with **v. 0.10.11**, this is an integer value which can be used to change the order that missions are offered. Missions with a higher offer precedence will be offered first. The default precedence value is 0, and this value can be negative. For missions with the same offer precedence, they will be offered in alphabetical order according to the identifier of the mission (i.e. the name of the mission specified on the `mission <name>` line, not the display name of the mission specified by the `name` token).
+
+Note that the way that the game determines which `minor` missions should offer means that the minor mission with the lowest precedence will be the one to offer, and all higher precedence minor missions that could have also offered at the same time will be discarded.
 
 # Conditions
 

--- a/wiki/CreatingMissions.md
+++ b/wiki/CreatingMissions.md
@@ -457,6 +457,8 @@ Beginning with **v. 0.10.11**, this is an integer value which can be used to cha
 
 Note that the way that the game determines which `minor` missions should offer means that the minor mission with the lowest precedence will be the one to offer, and all higher precedence minor missions that could have also offered at the same time will be discarded.
 
+Missions with the `job`, `boarding`, or `assisting` tags are not affected by this token. All available jobs will appear in the jobs board in whatever order is determined by the job sorting that the player has chosen. Only a single `boarding` or `assisting` mission can offer at a time, and the first mission in alphabetical order which is able to offer will be the one that does offer.
+
 # Conditions
 
 ["Conditions"](Player-Conditions) are named values that represent things the player has done. Conditions start out with a value of zero, and can only have integer values. Conditions can have almost any name you want, as long as you make sure not to use the same name in two places. A few names are reserved for special purposes and may be read-only. A list of these reserved conditions can be found [here](Player-Conditions#reserved-conditions-autoconditions).


### PR DESCRIPTION
**New feature**

> (If this PR is to include details on a new feature or a change to a feature, include a link to the PR that makes the corresponding change to Endless Sky.)
https://github.com/endless-sky/endless-sky/pull/<number>

There's a bit of a chicken and egg issue with this template. I need to create the PR on the main repo in order to reference the wiki PR, but I need to create the wiki PR in order to reference it on the main repo. 🤔

Anyway, here it is. https://github.com/endless-sky/endless-sky/pull/10887

## Summary
It be what it is.