### PR TITLE
Clarify that the sprite path of a stellar object has a meaning

### DIFF
--- a/wiki/MapData.md
+++ b/wiki/MapData.md
@@ -358,6 +358,8 @@ sprite <sprite>
 
 The sprite that is created at this object's position.
 
+Note that the sprite path is used to classify stellar objects: if it begins with "star/", it's a star, if it begins with "planet/station", it's a station, while any other object that has a parent object is classified as a moon. These classifications are used (or can be used in future versions) for messages, radar display and/or AI decisions.
+
 ```html
 scale <scale#>
 ```


### PR DESCRIPTION
**Correction/Clarification**

## Summary
I noticed this via code review, and thought it worth mentioning. I've intentionally left it a bit vague as to what the game uses these StellarObject flags for - a star gets a distinct radar visual and a minimum radius, AI::DoSurveillance uses some, and there's some [messages that I never managed to see in-game](https://github.com/endless-sky/endless-sky/blob/master/source/System.cpp#L442-L449)... Meaning, I don't understand the consequences in-depth, and a modder might be fine just knowing not to change the path conventions.
