### PR TITLE
feat(build): Remove scons, make developer the main build instruction location

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -50,7 +50,7 @@ These pages generally describe the game syntax in accordance with the [data form
 
 ### Compiling or modifying the source code
 
-* [Build instructions](https://github.com/endless-sky/endless-sky/blob/master/docs/readme-cmake.md)
+* [Build instructions](https://github.com/endless-sky/endless-sky/blob/master/docs/readme-developer.md)
 * [Contributing to the code](ContributingCode)
 * [C++ style guide](https://endless-sky.github.io/styleguide/styleguide.xml)
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -49,7 +49,7 @@
 
 **Compiling or modifying the source code**
 
-* [Build instructions](https://github.com/endless-sky/endless-sky/blob/master/docs/readme-cmake.md)
+* [Build instructions](https://github.com/endless-sky/endless-sky/blob/master/docs/readme-developer.md)
 * [Contributing to the code](ContributingCode)
 * [C++ style guide](https://endless-sky.github.io/styleguide/styleguide.xml)
 


### PR DESCRIPTION
**Build system update**

https://github.com/endless-sky/endless-sky/pull/11070

## Summary
Modifies the Wiki to refer to the build-instructions now in readme-developer.md instead of readme-cmake.md.