### PR TITLE
Fix `asteroids` key name in system definition

### DIFF
--- a/wiki/CreatingMinables.md
+++ b/wiki/CreatingMinables.md
@@ -29,7 +29,7 @@ The name of a minable must be unique.
 "display name" <display name>
 ```
 
-Beginning in **v. 0.10.0**, a minable can have a display name. This is the name that will be displayed to the player, for example, when they target this minable (with and asteroid scanner of some sort equipped). Unlike minable names, minable display names do not need to be unique.
+Beginning in **v. 0.10.0**, a minable can have a display name. This is the name that will be displayed to the player, for example, when they target this minable (with an asteroid scanner of some sort equipped). Unlike minable names, minable display names do not need to be unique.
 If no display name is provided, the name of the minable will be used.
 
 ```html

--- a/wiki/MapData.md
+++ b/wiki/MapData.md
@@ -47,7 +47,7 @@ system <name>
 	"jump range" <distance#>
 	haze <sprite>
 	link <system>
-	asteroid <name> <count#> <energy#>
+	asteroids <name> <count#> <energy#>
 	minables <name> <count#> <energy#>
 	trade <commodity> <cost#>
 	fleet <name> <period#>
@@ -146,7 +146,7 @@ system <name>
 	"jump range" <distance#>
 	haze <sprite>
 	link <system>
-	asteroid <name> <count#> <energy#>
+	asteroids <name> <count#> <energy#>
 	minables <name> <count#> <energy#>
 	trade <commodity> <cost#>
 	fleet <name> <period#>
@@ -282,13 +282,13 @@ link <system>
 The name of a system that this system is linked to. Linked systems can be traveled between using a hyperdrive or jump drive regardless of the distance. Systems can be linked to multiple other systems at once.
 
 ```html
-asteroid <name> <count#> <energy#>
+asteroids <name> <count#> <energy#>
 minables <name> <count#> <energy#>
 ```
 
 The name of the asteroids in this system, as well as the number of the asteroids and their energy. The energy of an asteroid determines how fast it moves and rotates, with higher values meaning faster asteroids. A random value between 0 and the energy value is used for each of the asteroids when they are created, meaning that high energy values may still result in slow asteroids.
 
-If an asteroid is minable, then it uses the `minable` keyword. Unlike normal asteroids, which travel randomly throughout the system and are [tiled](TiledAsteroids), minable asteroids will orbit around the system's `belt` distance. Note that minable asteroids names refer to a defined [minable](CreatingMinables), while normal asteroid names refer to the sprite name.
+If an asteroid is minable, then it uses the `minables` keyword. Unlike normal asteroids, which travel randomly throughout the system and are [tiled](TiledAsteroids), minable asteroids will orbit around the system's `belt` distance. Note that minable asteroids names refer to a defined [minable](CreatingMinables), while normal asteroid names refer to the sprite name.
 
 ```html
 trade <commodity> <cost#>


### PR DESCRIPTION
**Typo fix**

## Summary
The `system` sub-key is actually plural: https://github.com/endless-sky/endless-sky/blob/master/source/System.cpp#L243