### PR TITLE
Include different date formats in mission deadline substitution descriptions

### DIFF
--- a/wiki/CreatingMissions.md
+++ b/wiki/CreatingMissions.md
@@ -212,8 +212,8 @@ Certain characteristics of a mission, such as the cargo or the destination plane
 * `<marks>` = a list of all marked systems
 * `<payment>` = "1 credit" or "N credits," where N is the payment amount from the `on complete` block (or, beginning in **v. 0.10.0**, the "apparent payment" of the mission, if one is given), unless the replacement is in an `on *` block or below a conversation `action` node that has its own payment, in which case that `on *` block's or the most recent `action`'s payment is used
 * `<fine>` = "1 credit" or "N credits," where N is the fine amount with the same behavior as `<payment>`; this is not the fine as defined by an `illegal` line
-* `<date>` = the deadline for the mission (in the format "Day, DD Mon YYYY")
-* `<day>` = the deadline in conversational form ("the DDth of Month")
+* `<date>` = the deadline for the mission (in the format "Day, DD Mon YYYY", "Day Mon DD, YYYY", or "YYYY-MM-DD", depending on user settings)
+* `<day>` = the deadline in conversational form ("the DDth of Month" or "Month DDth", depending on user settings)
 * `<npc>` = the name of the last ship in the last `npc` block in the mission description
 * `<npc model>` = the model of the last ship in the last `npc` block in the mission description **(v. 0.10.0)**
 * `<first>` = your first name


### PR DESCRIPTION
**Correction/Clarification**

## Summary
The current descriptions of the `"<date>"` and `"<day>"` substitutions for missions (the deadline) only describe the default format, not the YMD and MDY formats. This adds those to the descriptions.