### PR TITLE
CreatingEvents: can change shrouded etc

### DIFF
--- a/wiki/CreatingEvents.md
+++ b/wiki/CreatingEvents.md
@@ -103,8 +103,14 @@ Update the named `galaxy`, including the `sprite` and position of the sprite on 
 
 ```html
 system <name>
+	inaccessible
+	remove inaccessible
 	hidden
 	remove hidden
+	shrouded
+	remove shrouded
+	"no raids"
+	remove "no raids"
 	pos <x#> <y#>
 	government <gov>
 	remove government


### PR DESCRIPTION
**Correction/Clarification**

## Summary
An event can change the hidden attribute of a system, that one is already documented. Missing was that inaccessible, shrouded and "no raids" work the same way. 

See: https://github.com/endless-sky/endless-sky/blob/master/source/System.cpp#L180-L187

Blame: [#9396](https://github.com/endless-sky/endless-sky/pull/9396), [#8118](https://github.com/endless-sky/endless-sky/pull/8118), [#9206](https://github.com/endless-sky/endless-sky/pull/9206)