### PR TITLE
Adding that Outfit/Ship Categories can be Customized by Data Files

### DIFF
--- a/wiki/CreatingOutfits.md
+++ b/wiki/CreatingOutfits.md
@@ -38,7 +38,9 @@ Outfits work by modifying the attributes of your ship. Many of the attributes ar
 
 Most attributes are given as a single number, but there are a few "special" attributes:
 
-* `category`: which outfitter category to show this outfit in. The outfit given must be a valid outfit category, which may be specified by a category `"outfit"` node **(v. 0.9.15)**. See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla outfit categories are the following:
+* `category`: which outfitter category to show this outfit in. The outfit given must be a valid outfit category.
+The list of available categories is specified by a `category "outfit"` node **(v. 0.9.15)**. See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example.
+The existing valid vanilla outfit categories are the following:
   * "Guns"
   * "Turrets"
   * "Secondary Weapons"

--- a/wiki/CreatingOutfits.md
+++ b/wiki/CreatingOutfits.md
@@ -47,10 +47,10 @@ Most attributes are given as a single number, but there are a few "special" attr
   * "Power"
   * "Engines"
   * "Hand to Hand"
-  * "Unique"
-  * "Minerals"
-  * "Special"
-  * "Licenses"
+  * "Unique" (**v0.10.12**)
+  * "Minerals" (**v0.10.12**)
+  * "Special" (**v0.10.12**)
+  * "Licenses" (**v0.10.12**)
 
 * `"display name"`: An alternative name to display in the UI for this outfit, can be used for renaming outfits if that ever becomes needed. This attribute should typically not be set, since we don't plan on renaming outfits often.
 

--- a/wiki/CreatingOutfits.md
+++ b/wiki/CreatingOutfits.md
@@ -38,7 +38,7 @@ Outfits work by modifying the attributes of your ship. Many of the attributes ar
 
 Most attributes are given as a single number, but there are a few "special" attributes:
 
-* `category`: which outfitter category to show this outfit in. The outfit given must be a valid outfit category, which may be specified by a category `"outfit"` node as of [0.9.15](https://github.com/endless-sky/endless-sky/commit/7f6e56a8302cb4a7fa6bd96fb72e5d1cb59f8982). See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla outfit categories are the following:
+* `category`: which outfitter category to show this outfit in. The outfit given must be a valid outfit category, which may be specified by a category `"outfit"` node **(v. 0.9.15)**. See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla outfit categories are the following:
   * "Guns"
   * "Turrets"
   * "Secondary Weapons"

--- a/wiki/CreatingOutfits.md
+++ b/wiki/CreatingOutfits.md
@@ -17,7 +17,7 @@ Any outfit model you create in Blender should use the camera and lighting settin
 ![](https://raw.githubusercontent.com/endless-sky/endless-sky/master/images/outfit/anti-missile.png)
 ![](https://raw.githubusercontent.com/endless-sky/endless-sky/master/images/outfit/medium%20ion%20thruster.png)
 
-The outfitter view divides outfits into difference categories: "Guns," "Turrets," etc. As another way of ensuring a consistent look, most outfits in a given section point in a certain direction:
+The outfitter view divides outfits into different categories: "Guns," "Turrets," etc. As another way of ensuring a consistent look, most outfits in a given section point in a certain direction:
 
 * Guns: top left.
 * Turrets: top left, and angled slightly up in the Z axis.
@@ -38,7 +38,7 @@ Outfits work by modifying the attributes of your ship. Many of the attributes ar
 
 Most attributes are given as a single number, but there are a few "special" attributes:
 
-* `category`: which outfitter category to show this outfit in. The category must be one of the following if it is to be purchasable:
+* `category`: which outfitter category to show this outfit in. The outfit given must be a valid outfit category, which may be specified by a category `"outfit"` node as of [0.9.15](https://github.com/endless-sky/endless-sky/commit/7f6e56a8302cb4a7fa6bd96fb72e5d1cb59f8982). See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla outfit categories are the following:
   * "Guns"
   * "Turrets"
   * "Secondary Weapons"
@@ -47,7 +47,10 @@ Most attributes are given as a single number, but there are a few "special" attr
   * "Power"
   * "Engines"
   * "Hand to Hand"
+  * "Unique"
+  * "Minerals"
   * "Special"
+  * "Licenses"
 
 * `"display name"`: An alternative name to display in the UI for this outfit, can be used for renaming outfits if that ever becomes needed. This attribute should typically not be set, since we don't plan on renaming outfits often.
 

--- a/wiki/CreatingShips.md
+++ b/wiki/CreatingShips.md
@@ -193,7 +193,7 @@ The data files use indentation, like in the Python language, to define sub-entri
 
 The `attributes` key should be followed by a list of ship attributes, ideally listed in the following order:
 
-* `"category"`: the type of ship, as specified by a `category "ship"` node as of [0.9.15](https://github.com/endless-sky/endless-sky/commit/7f6e56a8302cb4a7fa6bd96fb72e5d1cb59f8982). See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla `"ship"` categories are: "Transport", "Light Freighter", "Heavy Freighter", "Interceptor", "Light Warship", "Medium Warship", "Heavy Warship", "Fighter", or "Drone".
+* `"category"`: the type of ship, as specified by a `category "ship"` node since **v. 0.9.15**. See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla `"ship"` categories are: "Transport", "Light Freighter", "Heavy Freighter", "Interceptor", "Light Warship", "Medium Warship", "Heavy Warship", "Fighter", or "Drone".
 
   Since **v. 0.9.15**: also "Space Liner", or "Utility".
   Since **v. 0.10.0**: also "Superheavy".

--- a/wiki/CreatingShips.md
+++ b/wiki/CreatingShips.md
@@ -193,7 +193,7 @@ The data files use indentation, like in the Python language, to define sub-entri
 
 The `attributes` key should be followed by a list of ship attributes, ideally listed in the following order:
 
-* `"category"`: the type of ship: "Transport", "Light Freighter", "Heavy Freighter", "Interceptor", "Light Warship", "Medium Warship", "Heavy Warship", "Fighter", or "Drone".
+* `"category"`: the type of ship, as specified by a `category "ship"` node as of [0.9.15](https://github.com/endless-sky/endless-sky/commit/7f6e56a8302cb4a7fa6bd96fb72e5d1cb59f8982). See [categories.txt](https://github.com/endless-sky/endless-sky/blob/master/data/categories.txt) for an example. The existing valid vanilla `"ship"` categories are: "Transport", "Light Freighter", "Heavy Freighter", "Interceptor", "Light Warship", "Medium Warship", "Heavy Warship", "Fighter", or "Drone".
 
   Since **v. 0.9.15**: also "Space Liner", or "Utility".
   Since **v. 0.10.0**: also "Superheavy".


### PR DESCRIPTION
**Clarification(?)**

## Summary
In a [separate PR](https://github.com/endless-sky/endless-sky-wiki/pull/119#issuecomment-2778832840), Amazinite mentioned that wiki descriptions of Outfit & Ship categories should probably be updated to say that they can be updated by data files as of 0.9.15.

This does so, and mostly borrows the language already used to describe `bay <category>`.

This PR also adds missing vanilla outfit categories, and corrects a typo.