### PR TITLE
Adding existing vanilla log categories

### DIFF
--- a/wiki/CreatingMissions.md
+++ b/wiki/CreatingMissions.md
@@ -765,7 +765,7 @@ Some of the events below usually only make sense for certain triggers. In partic
 log [<category> <header>] <text>
 ```
 
-This creates a log entry in the player's log book, which is found on the player info page. Log entries are capable of having an optional category and header that they go under. If no category is given, then the log entry's header will be the date that the log was given, while the category will be the year.
+This creates a log entry in the player's log book, which is found on the player info page. Log entries are capable of having an optional category and header that they go under. If no category is given, then the log entry's header will be the date that the log was given, while the category will be the year. Existing vanilla categories are `"People"`, `"Minor People"`, and `"Factions"`.
 
 An example of how one might use the log category and header includes creating a category of logs on the various factions of the game, with the headers being each of the factions. If a log is given with a category and header that already has an entry, then the new log will go below the existing entry under the same header.
 

--- a/wiki/CreatingMissions.md
+++ b/wiki/CreatingMissions.md
@@ -765,9 +765,9 @@ Some of the events below usually only make sense for certain triggers. In partic
 log [<category> <header>] <text>
 ```
 
-This creates a log entry in the player's log book, which is found on the player info page. Log entries are capable of having an optional category and header that they go under. If no category is given, then the log entry's header will be the date that the log was given, while the category will be the year. Existing vanilla categories are `"People"`, `"Minor People"`, and `"Factions"`.
+This creates a log entry in the player's log book, which is found on the player info page. Log entries are capable of having an optional category and header that they go under. If no category is given, then the log entry's header will be the date that the log was given, while the category will be the year.
 
-An example of how one might use the log category and header includes creating a category of logs on the various factions of the game, with the headers being each of the factions. If a log is given with a category and header that already has an entry, then the new log will go below the existing entry under the same header.
+An example of how one might use the log category and header includes creating a category of logs on the various factions of the game, with the headers being each of the factions. Existing vanilla categories are `"People"`, `"Minor People"`, and `"Factions"`. If a log is given with a category and header that already has an entry, then the new log will go below the existing entry under the same header.
 
 ```html
 remove log <category> [<header>]


### PR DESCRIPTION
**Clarification**

## Summary
I was looking for the existing vanilla `log` categories in the wiki and could not find them. This PR adds them under `log` in "Creating Missions."

Thanks to Anarchist2 for sharing what they were in Discord.