### PR TITLE
fix: describe full behavior of the branch keyword in conversations

### DIFF
--- a/wiki/WritingConversations.md
+++ b/wiki/WritingConversations.md
@@ -197,7 +197,7 @@ A branch takes the conversation to one of two different labels depending on a se
 
 The `branch` keyword is followed by one or two label names. The first is the label to jump to if the subsequent conditions are all true. The second is the one to jump to if any of the conditions are false. If no second label is supplied, the "false" branch simply continues to the next entry in the conversation.
 
-If the label name is an endpoint, the conversation ends instead of jumping to the label. The corresponding effects for the endpoint are applied.
+An endpoint name can be used in place of a label name, in which case, the conversation ends instead of jumping to the label. The corresponding effects for the endpoint are applied. This also means that it is impossible for a `branch` node to branch to a label whose name matches an endpoint.
 
 ```js
 conversation

--- a/wiki/WritingConversations.md
+++ b/wiki/WritingConversations.md
@@ -197,6 +197,8 @@ A branch takes the conversation to one of two different labels depending on a se
 
 The `branch` keyword is followed by one or two label names. The first is the label to jump to if the subsequent conditions are all true. The second is the one to jump to if any of the conditions are false. If no second label is supplied, the "false" branch simply continues to the next entry in the conversation.
 
+If the label name is an endpoint, the conversation ends instead of jumping to the label. The corresponding effects for the endpoint are applied.
+
 ```js
 conversation
 	branch "famous"


### PR DESCRIPTION
**Correction/Clarification**

## Summary

Clarifies the behavior of the`branch` keyword based on how the game currently implements it. [Lines 175-179 in Conversation.cpp](https://github.com/endless-sky/endless-sky/blob/7f989a0ce347502b1ae0aae8f9ff77e3ecb72961/source/Conversation.cpp#L175-L179) are responsible this behavior.