### PR TITLE
Add a page describing how map labels are made

### DIFF
--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -39,6 +39,7 @@ These pages generally describe the game syntax in accordance with the [data form
 * [Creating system hazards](CreatingHazards)
 * [Creating minable asteroids](CreatingMinables)
 * [Creating planet sprites](PlanetSprites)
+* [Creating map label sprites](MapLabels)
 * [Creating spaceport news](CreatingNews)
 * [Creating governments](CreatingGovernments)
 * [Creating fleets](CreatingFleets)

--- a/wiki/MapLabels.md
+++ b/wiki/MapLabels.md
@@ -1,0 +1,32 @@
+The map contains various labels for the different regions of space, such as "The Core" and "Paradise Planets".
+These labels are sprites drawn on the map the same way as galaxies:
+
+```html
+galaxy "label core"
+	pos -136 130
+	sprite label/core
+
+galaxy "label deep"
+	pos -658 -300
+	sprite label/deep
+
+galaxy "label dirt belt"
+	pos -515 260
+	sprite "label/dirt belt"
+```
+
+Sometimes, a label is not added until the player has interacted with the local region, such as landing on a planet, or completing some step in a mission. This is done by defining a galaxy as above without a `sprite` and then adding the sprite with an event at the appropriate time:
+
+```html
+galaxy "label secret"
+	pos -750 615
+
+event "label secret space"
+	galaxy "label secret"
+		sprite label/secret
+```
+
+The existing map label have been created with InkScape (https://inkscape.org/).
+Create text with the Zapfino font (you may need to find a download for this), 24-point.
+Set the tracking (i.e. spacing between letters) to 24 px, and the fill color to bbc04030.
+Create a curve and use `Text` -> `Put on Path` to make the text follow that path. Adjust it as appropriate (possibly adjusting the spacing of individual letters to avoid overlapping the map text), then export as a PNG.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -35,6 +35,7 @@
 * [Creating system hazards](CreatingHazards)
 * [Creating minable asteroids](CreatingMinables)
 * [Creating planet sprites](PlanetSprites)
+* [Creating map label sprites](MapLabels)
 * [Creating spaceport news](CreatingNews)
 * [Creating governments](CreatingGovernments)
 * [Creating fleets](CreatingFleets)


### PR DESCRIPTION
**Missing documentation**

Resolves #48

## Summary
Adds a page to the wiki describing how the map labels are made.
Instructions come from a comment from MZ on the commit that added the first map labels: https://github.com/endless-sky/endless-sky/commit/fbf665dccdf8d9297cffdcb1f5fbdbaf3df0c4de#commitcomment-21479241
