### PR TITLE
Windows installer

### DIFF
--- a/wiki/HelpWanted.md
+++ b/wiki/HelpWanted.md
@@ -16,8 +16,6 @@ At the moment, the greatest need is for beta testers, but you can also contribut
 
 ### Programming tasks
 
-  * Windows: make and maintain an official installer.
-
   * macOS: build and distribute each release.
 
   * Linux: Debian package maintainer.


### PR DESCRIPTION
**New feature**

## Summary
https://github.com/endless-sky/endless-sky/pull/11522 adds an official installer, which means we no longer need help with that.

The weird diff is because there was no trailing newline.