### PR TITLE
Fix the description of what negative arrival distance values do

### DIFF
--- a/wiki/MapData.md
+++ b/wiki/MapData.md
@@ -270,7 +270,7 @@ departure [<distance#>]
 An additional distance at which ships arrive (or depart **(v0.9.17)**) in this system. If just `<distance#>` is provided, then both hyperdrive and jump drive travel into or out of a system has its distance moved. The `link <distance#>` and `jump <distance#>` lines are optional and allow for tweaking of the distance of each jump method. If a distance is given and then a link or jump distance is provided, the link or jump distance will override the distance. If a distance is given without a value and then a link or jump distance is provided, the other travel method will be unaffected.
 
 Negative values are allowed for link arrival distances, and will move the point at which the ship enters the system away from the direction it is coming from, rather than towards it as positive values do.
-Non-zero values (i.e. including this variable) will cause ships to jump into the system from a distance relative to the system center, as opposed to jumping in relative to a target planet.
+Providing a value other than zero will cause ships to jump into the system from a distance relative to the system center, as opposed to jumping in relative to a target planet.
 
 ```html
 ramscoop


### PR DESCRIPTION
**Correction/Clarification**

## Summary
The current description of the behaviour for negative link arrival distance values is inaccurate/confusing, since a negative value does not negate the position of the arrival point, it only subtracts from it, so it does not immediately put the point where the ship finishes exiting hyperspace on the other side of hte system, it will only do this with sufficiently large negative values.
I've updated it to better describe the behaviour.